### PR TITLE
Fix for neverending period loop

### DIFF
--- a/src/AutomationSwitchAccessory.js
+++ b/src/AutomationSwitchAccessory.js
@@ -191,7 +191,7 @@ class SwitchAccessory {
 
   nextPeriod() {
     this.signalMotion(false);
-    if (!this._state.autoOff) {
+    if (!this._state.autoOff || this._state.state === false) {
       this._startTimer();
     }
   }


### PR DESCRIPTION
When switch is turned off, the device stops triggering